### PR TITLE
[FT-207] Fix background color of EditButton in DetailAccountScreen

### DIFF
--- a/common/src/commonMain/kotlin/com/finance_tracker/finance_tracker/presentation/detail_account/views/EditButton.kt
+++ b/common/src/commonMain/kotlin/com/finance_tracker/finance_tracker/presentation/detail_account/views/EditButton.kt
@@ -65,7 +65,7 @@ internal fun EditButton(
             .clip(RoundedCornerShape(percent = 50))
             .noRippleClickable { onClick.invoke() }
             .road(Alignment.BottomEnd, Alignment.BottomEnd)
-            .background(CoinTheme.color.background)
+            .background(CoinTheme.color.white)
             .padding(vertical = state.animate(12.dp, 8.dp))
             .padding(start = 16.dp),
         verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
![telegram-cloud-photo-size-2-5393374447622276569-y](https://user-images.githubusercontent.com/22561563/216109526-9519f51e-d5a4-4926-b329-ead1433eddb5.jpg)
